### PR TITLE
Add Strakos Matrix

### DIFF
--- a/src/matrices/index.jl
+++ b/src/matrices/index.jl
@@ -57,6 +57,7 @@ export
     Rosser,
     Sampling,
     Smoke,
+    Strakos,
     Toeplitz,
     Triw,
     Wathen,
@@ -123,6 +124,7 @@ include("rohess.jl")
 include("rosser.jl")
 include("sampling.jl")
 include("smoke.jl")
+include("strakos.jl")
 include("toeplitz.jl")
 include("triw.jl")
 include("wathen.jl")
@@ -188,6 +190,7 @@ MATRIX_GROUPS[GROUP_BUILTIN] = Set([
     Rosser,
     Sampling,
     Smoke,
+    Strakos,
     Toeplitz,
     Triw,
     Wathen,

--- a/src/matrices/strakos.jl
+++ b/src/matrices/strakos.jl
@@ -1,0 +1,53 @@
+"""
+Strakos Matrix
+===============
+The Strakos matrix is used to study CG and Lanczos algorithm convergence. 
+
+# Input Options
+- dim: the dimension of the matrix.
+- p: controls eigenvalue distribution, typically 0.2<p<1 for clustering near λ1.
+- λ1: smallest eigenvalue, typically 1e-2 or 1e-3.
+- λn: largest eigenvalue, typically 1e2 or 1e3. 
+
+# References
+**Z. Strakoš,**
+On the real convergence rate of the conjugate gradient method, 
+Linear Algebra and its Applications, 154-156 (1991), pp. 535-549,
+https://doi.org/10.1016/0024-3795(91)90393-B.
+"""
+struct Strakos{T<:Real} <: AbstractMatrix{T}
+    n::Integer
+    p::T
+    λ1::T
+    λn::T
+
+    function Strakos{T}(n::Integer, p::T, λ1::T, λn::T) where T <: Real
+        n > 1 || throw(ArgumentError("n must be greater than 1. Got n=$n."))
+        p >= 0 || throw(ArgumentError("p must be non-negative for posdef. Got p=$p."))
+        λ1 > 0 || throw(ArgumentError("λ1 must be positive for posdef. Got λ1=$λ1."))
+        λn > λ1 || throw(ArgumentError("λn must be greater than λ1. Got λ1=$λ1, λn=$λn."))
+        return new{T}(n, p, λ1, λn)
+    end
+end
+
+# constructors
+function Strakos(n::Integer, p::Real, λ1::Real, λn::Real)
+    p_, λ1_, λn_ = promote(p, λ1, λn)
+    T = typeof(p_)
+    return Strakos{T}(n, p_, λ1_, λn_)
+end
+
+# metadata
+@properties Strakos [:eigen, :posdef, :symmetric, :illcond]
+
+# properties
+size(A::Strakos) = (A.n, A.n)
+
+# functions
+@inline Base.@propagate_inbounds function getindex(A::Strakos{T}, i::Integer, j::Integer) where T
+    if i==j
+        return T( A.λ1 + ((i-1)/(A.n-1))*(A.λn-A.λ1)*A.p^(A.n-i) )
+    else 
+        return zero(T)
+    end
+end

--- a/src/matrices/strakos.jl
+++ b/src/matrices/strakos.jl
@@ -21,12 +21,12 @@ struct Strakos{T<:Real} <: AbstractMatrix{T}
     λ1::T
     λn::T
 
-    function Strakos{T}(n::Integer, p::T, λ1::T, λn::T) where T <: Real
+    function Strakos{T}(n::Integer, p::Real, λ1::Real, λn::Real) where T <: Real
         n > 1 || throw(ArgumentError("n must be greater than 1. Got n=$n."))
         p >= 0 || throw(ArgumentError("p must be non-negative for posdef. Got p=$p."))
         λ1 > 0 || throw(ArgumentError("λ1 must be positive for posdef. Got λ1=$λ1."))
         λn > λ1 || throw(ArgumentError("λn must be greater than λ1. Got λ1=$λ1, λn=$λn."))
-        return new{T}(n, p, λ1, λn)
+        return new{T}(n, T(p), T(λ1), T(λn))
     end
 end
 
@@ -36,6 +36,9 @@ function Strakos(n::Integer, p::Real, λ1::Real, λn::Real)
     T = typeof(p_)
     return Strakos{T}(n, p_, λ1_, λn_)
 end
+
+Strakos(n::Integer) = Strakos(n, 0.5, 0.1, 100)
+Strakos{T}(n::Integer) where T = Strakos{T}(n, 0.5, 0.1, 100)
 
 # metadata
 @properties Strakos [:eigen, :posdef, :symmetric, :illcond]

--- a/test/matrices/strakos.jl
+++ b/test/matrices/strakos.jl
@@ -1,0 +1,16 @@
+# constructors 
+@test allequal([
+    Strakos(5, 5e-1, 1, 1e3),
+    Strakos(5, 0.5, 1, 1000),
+    Strakos{Float64}(5, 0.5, 1, 1000),
+])
+
+# linear algebra functions
+run_test_linear_algebra_functions(Strakos.(2:5))
+run_test_properties(Strakos, 5)
+
+# eltype
+@test test_matrix_elements(Strakos{Float32}(5))
+
+# content
+@test Strakos(4, 0.5, 1, 7) ≈ [1 0 0 0; 0 1.5 0 0; 0 0 3 0; 0 0 0 7]


### PR DESCRIPTION
The Strakoš matrix is a popular test matrix for Krylov methods and appears frequently in literature e.g. [Greenbaum and Strakoš](https://doi.org/10.1137/0613011) and [Carson and Gergelits](https://doi.org/10.48550/arXiv.2103.09210). 

This PR adds type `Strakos` (via `src/matrices/strakos.jl`) and extends `size` and `getindex`. Inner constructor enforces posdef. 

If TypedMatrices.jl is interested, I will complete the checklist below. 

**TODO:**
- [x] Modify `src/matrices/index.jl`. 
- [x] Add `Strakos(n::Int)` method for compatibility with `run_test_properties`
- [x] Write tests. 